### PR TITLE
Add unit tests + coverage; fixed identified issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ __pycache__
 *.egg-info
 docs/generated
 .coverage
+*.lcov
+htmlcov
 pytest.xml

--- a/docs/stubbing.rst
+++ b/docs/stubbing.rst
@@ -285,14 +285,11 @@ Stub Properties
     ...         return "Spam"
 
     >>> menu = mock(Menu)
-
-    >>> when(menu.daily_special).any_call().then_return(
-    ...     "Sausage, eggs, spam, bacon, and spam",
-    ... )
-
-    # ❌ Fail
     >>> menu.daily_special
-    MethodMock[* -> Sausage, eggs, spam, bacon, and spam]
+    Traceback (most recent call last):
+    ...
+    ValueError: MockSafe doesn't currently support properties, so SafeMock[Menu#...].daily_special could not be mocked.
+
 
 
 Raise Error

--- a/mocksafe/spy.py
+++ b/mocksafe/spy.py
@@ -57,6 +57,8 @@ class MethodSpy(Generic[T]):
                 raise ValueError(f"The mocked method {self._name}() was not called.")
 
             raise ValueError(
-                f"Mocked method {self._name}() was not called {n+1} time(s). "
-                f"The actual number of calls was {len(self.calls)}.",
+                (
+                    f"Mocked method {self._name}() was not called {n+1} time(s). "
+                    f"The actual number of calls was {len(self.calls)}."
+                ),
             )

--- a/mocksafe/stub.py
+++ b/mocksafe/stub.py
@@ -77,7 +77,11 @@ class MethodStub(Generic[T]):
                 continue
             if not type_match(e, self._result_type):
                 raise TypeError(
-                    f"Cannot use stub result {e} ({type(e)}) with the mocked method {self._name}(), the expected return type is: {self._result_type}.",
+                    (
+                        f"Cannot use stub result {e} ({type(e)}) with the mocked method"
+                        f" {self._name}(), the expected return type is:"
+                        f" {self._result_type}."
+                    ),
                 )
 
 

--- a/mocksafe/when_then.py
+++ b/mocksafe/when_then.py
@@ -25,7 +25,9 @@ def when(mock_method: Callable[..., T]) -> WhenStubber[T]:
         >>> when(mock_random.random).any_call().then_return(0.31)
     """
     if not isinstance(mock_method, MethodMock):
-        raise ValueError("Not a SafeMocked method: mock_method")
+        raise ValueError(
+            f"Not a SafeMocked method: {mock_method} ({type(mock_method)})"
+        )
     return WhenStubber(mock_method)
 
 
@@ -39,14 +41,24 @@ class WhenStubber(Generic[T]):
     See: :class:`mocksafe.MatchCallStubber`
 
     :Example:
-        >>> when(mock_random.randint).called_with(mock_random.randint(1, 10)).then_return(7)
+        >>> when(
+        ...     mock_random.randint
+        ... ).called_with(
+        ...     mock_random.randint(1, 10)
+        ... ).then_return(7)
+
         >>> mock_random.randint(1, 10)
         7
 
     See: :class:`mocksafe.LastCallStubber`
 
     :Example:
-        >>> when(mock_random.randint).call_matching(lambda a, b: a <= 3 and b > 3).then_return(3)
+        >>> when(
+        ...     mock_random.randint
+        ... ).call_matching(
+        ...     lambda a, b: a <= 3 and b > 3
+        ... ).then_return(3)
+
         >>> mock_random.randint(2, 6)
         3
 
@@ -101,7 +113,12 @@ class MatchCallStubber(Generic[T]):
         >>> when(mock_random.randint).any_call().then(lambda a, b: int((b - a) / 2))
 
     :Example:
-        >>> when(mock_random.randint).any_call().use_side_effects(1, 2, 3, ValueError("..."), 4)
+        >>> when(
+        ...     mock_random.randint
+        ... ).any_call().use_side_effects(
+        ...     1, 2, 3, ValueError("..."), 4
+        ... )
+
     """
 
     def __init__(
@@ -143,19 +160,43 @@ class LastCallStubber(Generic[T]):
     condition matches.
 
     :Example:
-        >>> when(mock_random.randint).called_with(mock_random.randint(1, 2)).then_return(0.31)
+        >>> when(
+        ...     mock_random.randint
+        ... ).called_with(
+        ...     mock_random.randint(1, 2)
+        ... ).then_return(0.31)
 
     :Example:
-        >>> when(mock_random.randint).called_with(mock_random.randint(3, 4)).then_return(0.1, 0.3, 0.2)
+        >>> when(
+        ...     mock_random.randint
+        ... ).called_with(
+        ...     mock_random.randint(3, 4)
+        ... ).then_return(0.1, 0.3, 0.2)
 
     :Example:
-        >>> when(mock_random.randint).called_with(mock_random.randint(5, 6)).then_raise(ValueError("..."))
+        >>> when(
+        ...     mock_random.randint
+        ... ).called_with(
+        ...     mock_random.randint(5, 6)
+        ... ).then_raise(ValueError("..."))
 
     :Example:
-        >>> when(mock_random.randint).called_with(mock_random.randint(7, 8)).then(lambda a, b: int((b - a) / 2))
+        >>> when(
+        ...     mock_random.randint
+        ... ).called_with(
+        ...     mock_random.randint(7, 8)
+        ... ).then(
+        ...     lambda a, b: int((b - a) / 2)
+        ... )
 
     :Example:
-        >>> when(mock_random.randint).called_with(mock_random.randint(9, 10)).use_side_effects(1, 2, 3, ValueError("..."), 4)
+        >>> when(
+        ...     mock_random.randint
+        ... ).called_with(
+        ...     mock_random.randint(9, 10)
+        ... ).use_side_effects(
+        ...     1, 2, 3, ValueError("..."), 4
+        ... )
     """
 
     def __init__(self: LastCallStubber, method_mock: MethodMock[T]):
@@ -175,7 +216,11 @@ class LastCallStubber(Generic[T]):
     ) -> None:
         if not self._method_mock.calls:
             raise ValueError(
-                f"Mocked methods do not match: when({self._method_mock.full_name}).called_with(<different_method>)",
+                (
+                    "Mocked methods do not match: "
+                    f"when({self._method_mock.full_name})"
+                    ".called_with(<different_method>)"
+                ),
             )
 
         self._method_mock.stub_last_call(list(side_effects))

--- a/tests/mocksafe/test_call_matchers.py
+++ b/tests/mocksafe/test_call_matchers.py
@@ -1,0 +1,39 @@
+from mocksafe.call_matchers import AnyCallMatcher, ExactCallMatcher, CustomCallMatcher
+from mocksafe.custom_types import Call
+
+
+ANY_CALL: Call = ((), {})
+
+
+def test_any_call_matcher():
+    matcher = AnyCallMatcher()
+
+    assert matcher(ANY_CALL) is True
+
+    assert str(matcher) == "*"
+
+
+def test_exact_call_matcher():
+    exact: Call = (("foo", "bar"), {"baz": "quux"})
+
+    matcher = ExactCallMatcher(exact)
+
+    assert matcher(ANY_CALL) is False
+    assert matcher(exact) is True
+
+    assert str(matcher) == "call(foo, bar, baz=quux)"
+
+
+def test_custom_call_matcher():
+    matcher = CustomCallMatcher(lambda x: x == 2)
+
+    def call_maker(x: int) -> Call:
+        return ((x,), {})
+
+    assert matcher(call_maker(1)) is False
+    assert matcher(call_maker(2)) is True
+    assert matcher(call_maker(3)) is False
+
+    assert str(matcher).startswith(
+        "<function test_custom_call_matcher.<locals>.<lambda>"
+    )

--- a/tests/mocksafe/test_call_type_validator.py
+++ b/tests/mocksafe/test_call_type_validator.py
@@ -1,0 +1,420 @@
+import sys
+import contextlib
+import random
+from inspect import Parameter
+from types import ModuleType
+from typing import (
+    Mapping,
+    ContextManager,
+    Callable,
+    Sequence,
+    Union,
+    Optional,
+    Any,
+    Generator,
+)
+from collections import OrderedDict
+from collections.abc import Iterable, Iterator, Sized
+from decimal import Decimal
+from fractions import Fraction
+
+import pytest
+
+from mocksafe.call_type_validator import CallTypeValidator
+
+
+ANY_NAME = "any_name"
+ANY_PARAMETER = Parameter(ANY_NAME, Parameter.POSITIONAL_OR_KEYWORD)
+
+NO_PARAMS: Mapping[str, Parameter] = {}
+SELF_PARAM: Mapping[str, Parameter] = {"self": ANY_PARAMETER}
+
+
+async def async_function():
+    ...
+
+
+def test_validate_no_params():
+    validator = CallTypeValidator(ANY_NAME, NO_PARAMS, (), {})
+    validator.validate()
+
+
+def test_validate_too_many_args():
+    validator = CallTypeValidator(ANY_NAME, NO_PARAMS, ("one too many args",), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validate_too_many_kwargs():
+    validator = CallTypeValidator(ANY_NAME, NO_PARAMS, (), {"too_many": "kwargs"})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validator_ignores_self_arg():
+    validator = CallTypeValidator(ANY_NAME, SELF_PARAM, (), {})
+    validator.validate()
+
+
+def test_validates_missing_positional_arg():
+    positional_param = Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY)
+    params = OrderedDict(**SELF_PARAM, **{ANY_NAME: positional_param})
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {})
+
+    with pytest.raises(TypeError):
+        validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"unexpected": "keyword"})
+
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_missing_kwarg():
+    kw_param = Parameter(ANY_NAME, Parameter.KEYWORD_ONLY)
+    params = OrderedDict(**SELF_PARAM, **{ANY_NAME: kw_param})
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {})
+
+    with pytest.raises(TypeError):
+        validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, ("unexpected-arg",), {})
+
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_matching_arg():
+    params = {ANY_NAME: Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY)}
+
+    validator = CallTypeValidator(ANY_NAME, params, ("this arg matches",), {})
+
+    validator.validate()
+
+
+def test_validates_matching_kwarg():
+    params = {"foo": Parameter("foo", Parameter.KEYWORD_ONLY)}
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"foo": "bar"})
+
+    validator.validate()
+
+
+def test_validates_matching_either_arg():
+    params = {"foo": Parameter("foo", Parameter.POSITIONAL_OR_KEYWORD)}
+
+    validator = CallTypeValidator(ANY_NAME, params, ("bar",), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"foo": "bar"})
+    validator.validate()
+
+
+def test_validates_mixed_param_kinds():
+    params = OrderedDict(**SELF_PARAM)
+    params["foo"] = Parameter("foo", Parameter.POSITIONAL_ONLY)
+    params["bar"] = Parameter("bar", Parameter.KEYWORD_ONLY)
+
+    validator = CallTypeValidator(ANY_NAME, params, ("baz",), {"bar": "quux"})
+    validator.validate()
+
+
+def test_validates_varargs():
+    params = {"args": Parameter("args", Parameter.VAR_POSITIONAL)}
+
+    validator = CallTypeValidator(ANY_NAME, params, ("foo",), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, ("foo", "bar", "baz"), {})
+    validator.validate()
+
+
+def test_validates_var_kwargs():
+    params = {"kwargs": Parameter("kwargs", Parameter.VAR_KEYWORD)}
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"foo": "bar"})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"baz": "quux", "foo": "bar"})
+    validator.validate()
+
+
+@pytest.mark.parametrize(
+    "arg_value,param_type",
+    [
+        # Built-ins, collections, "primitive" types, etc.
+        (True, bool),
+        (123, int),
+        (3.45, float),
+        (2j, complex),
+        (Decimal("1.23"), Decimal),
+        (Fraction(1, 4), Fraction),
+        ([1, 2, 3], Iterable),
+        ("string", Iterable),
+        ((1, 2, 3), Iterable),
+        ({"a": "b"}, Iterable),
+        ({"a": "b"}, Iterable),
+        (iter([1, 2, 3]), Iterator),
+        ([1, 2, 3], Sequence),
+        ("string", Sequence),
+        ((1, 2, 3), Sequence),
+        ([1, 2, 3], list),
+        (("a", "b"), tuple),
+        (range(10), range),
+        ("hi", str),
+        (b"hello", bytes),
+        (bytearray(b"\xf0\xf1\xf2"), bytearray),
+        (memoryview(b"abcefg"), memoryview),
+        ({1, 2, 3}, set),
+        (frozenset({4, 5, 6, 6}), frozenset),
+        ({"a": "b"}, dict),
+        (contextlib.nullcontext(), ContextManager),
+        (lambda: None, Callable),
+        (type(int), type),
+        (None, object),
+        (None, type(None)),
+        (..., type(Ellipsis)),
+        (NotImplemented, type(NotImplemented)),
+        (async_function, Callable),
+        # String literal types
+        # E.g.  def f(n: "int")
+        (True, "bool"),
+        (123, "int"),
+        (3.45, "float"),
+        (2j, "complex"),
+        ([1, 2, 3], "list"),
+        (("a", "b"), "tuple"),
+        (range(10), "range"),
+        ("hi", "str"),
+        (b"hello", "bytes"),
+        (bytearray(b"\xf0\xf1\xf2"), "bytearray"),
+        (memoryview(b"abcefg"), "memoryview"),
+        ({1, 2, 3}, "set"),
+        (frozenset({4, 5, 6, 6}), "frozenset"),
+        ({"a": "b"}, "dict"),
+        (type(int), "type"),
+        (None, "object"),
+    ],
+)
+def test_validates_standard_types(arg_value: Any, param_type: Any):
+    params = {
+        ANY_NAME: Parameter(
+            ANY_NAME, Parameter.POSITIONAL_OR_KEYWORD, annotation=param_type
+        )
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (arg_value,), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {ANY_NAME: arg_value})
+    validator.validate()
+
+    if arg_value is not None:
+        validator = CallTypeValidator(ANY_NAME, params, (None,), {})
+        with pytest.raises(TypeError):
+            validator.validate()
+
+
+@pytest.mark.parametrize(
+    "arg_value,param_type",
+    [
+        (True, Union[bool, int]),
+        (123, Union[bool, int]),
+        ("yes", Optional[str]),
+        (None, Optional[str]),
+        (True, Union[bool, None]),
+        (None, Union[bool, None]),
+        # New union syntax in Python 3.10+ only
+        *(
+            [
+                (True, bool | int),
+                (123, bool | int),
+                ("yes", str | None),
+                (None, str | None),
+            ]
+            if sys.version_info[:3] >= (3, 10)
+            else []
+        ),
+    ],
+)
+def test_validates_union_types(arg_value: Any, param_type: Any):
+    params = {
+        ANY_NAME: Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=param_type)
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (arg_value,), {})
+    validator.validate()
+
+    if arg_value is not None:
+        wrong_type: bytes = b"this shouldn't match the param_type"
+        validator = CallTypeValidator(ANY_NAME, params, (wrong_type,), {})
+        with pytest.raises(TypeError):
+            validator.validate()
+
+
+def test_validates_class_type():
+    # Validate with collections.abc.Sized, a really simple (abstract) class type
+    params = {
+        ANY_NAME: Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=Sized)
+    }
+
+    sized_arg: Sized = [1, 2, 3]
+
+    assert isinstance(sized_arg, Sized)
+
+    unsized_arg = False
+
+    validator = CallTypeValidator(ANY_NAME, params, (sized_arg,), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (unsized_arg,), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_module_types():
+    params = {
+        ANY_NAME: Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=ModuleType)
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (random,), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, ("not random at all",), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_callable_types():
+    params = {
+        ANY_NAME: Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=Callable)
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (lambda: None,), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, ("not callable",), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+@pytest.mark.parametrize(
+    "arg_value,param_type",
+    [
+        ({"x": 1, "y": 2}, dict[str, int]),
+        ((1, 2, 3), tuple[int]),
+        (
+            [
+                "generic",
+                "type",
+                "parameters",
+                "can't",
+                "actually",
+                "be validated",
+                "at",
+                "runtime",
+            ],
+            list[int],
+        ),
+        (lambda: None, Callable[[bool, int], str]),
+        (
+            [
+                "The",
+                "contents",
+                "of",
+                "this",
+                "Sequence",
+                "can",
+                "still",
+                "be",
+                "anything",
+            ],
+            Sequence[bool],
+        ),
+    ],
+)
+def test_validates_generic_types(arg_value: Any, param_type: Any):
+    params = {
+        ANY_NAME: Parameter(ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=param_type)
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (arg_value,), {})
+    validator.validate()
+
+
+@pytest.mark.parametrize(
+    "bad_value,expected_type",
+    [
+        ([], dict[str, int]),
+        ({}, tuple[int]),
+        ((), list[int]),
+        ("not callable", Callable[..., bool]),
+        ({"not", "a", "Sequence"}, Sequence[str]),
+    ],
+)
+def test_ensures_generic_origin_type(bad_value: Any, expected_type: Any):
+    params = {
+        ANY_NAME: Parameter(
+            ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=expected_type
+        )
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (bad_value,), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_generator():
+    def generate() -> Generator[int, None, None]:
+        yield from range(10)
+
+    params = {
+        ANY_NAME: Parameter(
+            ANY_NAME, Parameter.POSITIONAL_ONLY, annotation=Generator[int, None, None]
+        )
+    }
+
+    validator = CallTypeValidator(ANY_NAME, params, (generate(),), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, ([1, 2, 3],), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_typed_var_args():
+    params = {"args": Parameter("args", Parameter.VAR_POSITIONAL, annotation=int)}
+
+    validator = CallTypeValidator(ANY_NAME, params, (1,), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (1, 2, 3), {})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, ("bad",), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (1, 2, "bad"), {})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+
+def test_validates_typed_var_kwargs():
+    params = {"kwargs": Parameter("kwargs", Parameter.VAR_KEYWORD, annotation=int)}
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"x": 1})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"x": 1, "y": 2, "z": 3})
+    validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"bad": "type"})
+    with pytest.raises(TypeError):
+        validator.validate()
+
+    validator = CallTypeValidator(ANY_NAME, params, (), {"x": 1, "bad": "type"})
+    with pytest.raises(TypeError):
+        validator.validate()

--- a/tests/mocksafe/test_call_type_validator.py
+++ b/tests/mocksafe/test_call_type_validator.py
@@ -229,10 +229,10 @@ def test_validates_standard_types(arg_value: Any, param_type: Any):
         # New union syntax in Python 3.10+ only
         *(
             [
-                (True, bool | int),
-                (123, bool | int),
-                ("yes", str | None),
-                (None, str | None),
+                (True, bool | int),  # type: ignore
+                (123, bool | int),  # type: ignore
+                ("yes", str | None),  # type: ignore
+                (None, str | None),  # type: ignore
             ]
             if sys.version_info[:3] >= (3, 10)
             else []

--- a/tests/mocksafe/test_mock.py
+++ b/tests/mocksafe/test_mock.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from mocksafe.mock import SafeMock, MethodMock, mock_reset
+
+
+class TestClass:
+    def foo(self: TestClass):
+        ...
+
+    @property
+    def bar(self: TestClass) -> int:
+        return -1
+
+
+def test_mock_reset():
+    mock_object = SafeMock(TestClass)
+
+    mock_object.foo()
+
+    foo: MethodMock = mock_object.mocked_methods["foo"]
+
+    assert len(foo.calls) == 1
+
+    mock_reset(mock_object)
+
+    assert len(foo.calls) == 0

--- a/tests/mocksafe/test_spy.py
+++ b/tests/mocksafe/test_spy.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+import inspect
+import pytest
+from mocksafe.spy import MethodSpy
+
+
+class TestClass:
+    def foo(self: TestClass, bar: int, baz: str = "quux") -> int:
+        return bar + len(baz)
+
+
+INSTANCE = TestClass()
+METHOD = INSTANCE.foo
+NAME = METHOD.__name__
+SIGNATURE = inspect.signature(INSTANCE.foo)
+
+
+def test_spy_delegation():
+    foo = MethodSpy(NAME, METHOD, SIGNATURE)
+    assert foo(1, baz="a") == 2
+
+
+def test_spy_calls():
+    foo = MethodSpy(NAME, METHOD, SIGNATURE)
+
+    assert not foo.calls
+
+    foo(1, baz="a")
+
+    assert foo.calls == [((1,), {"baz": "a"})]
+
+
+def test_spy_nth_call():
+    foo = MethodSpy(NAME, METHOD, SIGNATURE)
+
+    with pytest.raises(ValueError):
+        foo.nth_call(0)
+
+    foo(2)
+
+    assert foo.nth_call(0) == ((2,), {})
+
+    with pytest.raises(ValueError):
+        foo.nth_call(1)
+
+
+def test_spy_pop_call():
+    foo = MethodSpy(NAME, METHOD, SIGNATURE)
+
+    foo(1, baz="a")
+
+    assert foo.pop_call() == ((1,), {"baz": "a"})
+
+    with pytest.raises(IndexError):
+        foo.pop_call()
+
+
+def test_spy_info():
+    foo = MethodSpy(NAME, METHOD, SIGNATURE)
+
+    foo(1)
+
+    assert str(foo) == "MethodSpy[foo:1 call(s)]"
+    assert foo.name == NAME

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pytest-cov>=4
     pytest-sugar
 commands =
-    pytest --cov-report=lcov --cov=mocksafe {posargs:tests}
+    pytest --cov-report=lcov --cov-report=html --cov=mocksafe {posargs:tests}
 
 [testenv:mypy]
 description = run mypy checks
@@ -25,7 +25,7 @@ description = code formatting
 skip_install = true
 deps =
     black==23.3.0
-commands = black {posargs:.}
+commands = black --preview {posargs:.}
 
 [testenv:lint]
 deps =
@@ -52,16 +52,21 @@ deps =
     flake8-simplify
     flake8-warnings
     flake8-eradicate
+    flake8-continuation
     pep8-naming
 commands =
     flake8 {posargs:mocksafe tests}
 
 [flake8]
-ignore = E501, RST304, ANN002, ANN003, ANN204, ANN401
+# Align with black
+max-line-length = 88
+
+ignore = RST304, ANN002, ANN003, ANN204, ANN401
+
 per-file-ignores =
     # Ignore F401 'imported but unused' in __init__.py files
     */__init__.py: F401
-    tests/**.py: S101, ANN101, ANN201
+    tests/**.py: S101, ANN101, ANN201, SIM907
 
 [testenv:docs]
 description = build sphinx docs

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,6 @@ deps =
     flake8-simplify
     flake8-warnings
     flake8-eradicate
-    flake8-continuation
     pep8-naming
 commands =
     flake8 {posargs:mocksafe tests}

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
     pytest --cov-report=lcov --cov-report=html --cov=mocksafe {posargs:tests}
 
 [testenv:mypy]
+basepython=39
 description = run mypy checks
 deps =
     pytest>=7


### PR DESCRIPTION
Addresses: https://github.com/dmayo3/mocksafe/issues/13

Fixes and improvements:

* Explicitly don't support mocking properties as it's not working
* More thorough runtime type checks
* Fixed `mocksafe.mock_reset()`

Tests:

* Add some unit tests and increase coverage further (+5.70% to 93%)
* Generate HTML coverage reports as well as LCOV, for more convenient local use

Code style:

* Follow PEP8 recommendation for using parentheses for continuation rather than backslashes
* Use `black --preview` mode to format long strings
* Tweak line length linting

Type checks:
* Run mypy with basepython 3.9 to catch compatibility issues quicker