### PR TITLE
Add semver 2.0.0 badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@
 .. image:: https://badge.fury.io/py/mocksafe.svg
     :target: https://badge.fury.io/py/mocksafe
     :alt: PyPI Package
+.. image:: https://img.shields.io/badge/semver-2.0.0-blue
+    :target: https://semver.org/
+    :alt: Follows the Semantic Versioning 2.0.0 spec
 .. image:: https://img.shields.io/pypi/pyversions/mocksafe.svg
     :target: https://pypi.org/project/mocksafe
     :alt: Supported versions


### PR DESCRIPTION
Indicate adherence to the semantic versioning.

For what it's worth, this means little for a pre 1.0 alpha but backwards compatibility is still being kept as much as possible.