### PR TITLE
Try to avoid implicit hard dependency on particular version of pytest

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,7 @@ API
    :toctree: generated
 
    mocksafe
+   mocksafe.plugin
    mocksafe.mock
    mocksafe.mock_module
    mocksafe.mock_reset

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,4 +57,5 @@ Contents
    stubbing
    verification
    typesafety
+   plugin
    api

--- a/docs/plugin.rst
+++ b/docs/plugin.rst
@@ -1,0 +1,25 @@
+Pytest Plugin (optional)
+========================
+
+This plugin provides a Pytest fixture that can be used to monkeypatch
+attributes on objects with mocks.
+
+This is a convenience that builds on top of pytest's `monkeypatch`
+(`pytest.MonkeyPatch`) fixture.
+
+To use this plugin, a compatible version of pytest (>=6.2) must be installed.
+
+Here's an example of using the patch fixture to mock out the default
+Random number generator in the `random` module:
+
+.. doctest::
+
+    >>> import pytest
+    >>> import random
+    >>> from mocksafe.plugin import Patcher
+
+    >>> @pytest.fixture
+    ... def mock_random(patch: Patcher) -> random.Random:
+    ...     return patch(random, "_inst", random.Random)
+
+For more information see: :mod:`mocksafe.plugin`

--- a/mocksafe/plugin.py
+++ b/mocksafe/plugin.py
@@ -1,26 +1,51 @@
+"""
+This module provides an optional pytest plugin for mocksafe for
+monkeypatching.
+
+It is only available when the minimum required version of pytest
+is installed, which should be >= 6.2.0.
+
+When installed the plugin exposes a `patch` fixture that implements
+the `Patcher` Protocol defined in this module.
+"""
+import logging
 from typing import Protocol, TypeVar
-import pytest
 from mocksafe import mock
 
+try:
+    import pytest
 
-T = TypeVar("T")
+    T = TypeVar("T")
 
+    class _Patcher:
+        def __init__(self, monkeypatch: pytest.MonkeyPatch):
+            self._monkeypatch = monkeypatch
 
-class _Patcher:
-    def __init__(self, monkeypatch: pytest.MonkeyPatch):
-        self._monkeypatch = monkeypatch
+        def patch(self, obj: object, attr: str, class_type: type[T]) -> T:
+            mock_obj: T = mock(class_type)
+            self._monkeypatch.setattr(obj, attr, mock_obj)
+            return mock_obj
 
-    def patch(self, obj: object, attr: str, class_type: type[T]) -> T:
-        mock_obj: T = mock(class_type)
-        self._monkeypatch.setattr(obj, attr, mock_obj)
-        return mock_obj
+    class Patcher(Protocol):
+        def __call__(self, obj: object, attr: str, class_type: type[T]) -> T:
+            """
+            Patch an attribute on an object with a mock object.
 
+            Args:
+                obj: The object to patch.
+                attr: The attribute to patch.
+                class_type: The type of the class to mock.
 
-class Patcher(Protocol):
-    def __call__(self, obj: object, attr: str, class_type: type[T]) -> T:
-        ...
+            Returns:
+                The mock object patched on to `obj`.
+            """
+            ...  # pylint: disable=unnecessary-ellipsis
 
+    @pytest.fixture
+    def patch(monkeypatch: pytest.MonkeyPatch) -> Patcher:
+        return _Patcher(monkeypatch).patch
 
-@pytest.fixture
-def patch(monkeypatch: pytest.MonkeyPatch) -> Patcher:
-    return _Patcher(monkeypatch).patch
+except (ImportError, AttributeError):
+    logging.getLogger(__name__).debug(
+        "pytest not importable so not installing mocksafe pytest plugin"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ Documentation = "https://mocksafe.readthedocs.io/en/0.6/"
 Source = "https://github.com/dmayo3/mocksafe"
 
 [project.optional-dependencies]
-docs = ["sphinx-rtd-theme >= 1.2.0"]
+pytest = ["pytest >= 6.2.0"]
+docs = ["sphinx-rtd-theme >= 1.2.0", "pytest >= 6.2.0"]
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".tox",
+  "venv": "pyright"
+}


### PR DESCRIPTION
* Fixes #61

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--63.org.readthedocs.build/en/63/

<!-- readthedocs-preview mocksafe end -->