### PR TITLE
Provide a better way to capture kwargs from a call

### DIFF
--- a/docs/verification.rst
+++ b/docs/verification.rst
@@ -128,3 +128,46 @@ Example:
     >>> kwargs
     {'interrogator': 'Cardinal Biggles'}
     >>> assert kwargs.get("interrogator") == "Cardinal Biggles"
+
+
+Capture Details for All Calls
+-----------------------------
+
+If you prefer to capture the details of all calls that were made for deeper
+inspection you can use the ``all_calls`` attribute of the spy object using
+expressions such as::
+
+    <var> = spy(<mock>).all_calls
+
+Example:
+
+.. doctest::
+
+    >>> class SpanishInquisition:
+    ...     def surprise(self, location: str, interrogator: str) -> str:
+    ...         raise NotImplementedError()
+
+    >>> inquisitors = mock(SpanishInquisition)
+
+    >>> when(inquisitors.surprise).any_call().then(
+    ...     lambda location, interrogator: (
+    ...         f"The Spanish Inquisition surprises {location} with {interrogator}!"
+    ...     )
+    ... )
+
+    >>> inquisitors.surprise("the village", interrogator="Cardinal Biggles")
+    'The Spanish Inquisition surprises the village with Cardinal Biggles!'
+
+    >>> inquisitors.surprise("the castle", interrogator="Cardinal Fang")
+    'The Spanish Inquisition surprises the castle with Cardinal Fang!'
+
+    >>> inquisitors.surprise("the town square", interrogator="Cardinal Ximinez")
+    'The Spanish Inquisition surprises the town square with Cardinal Ximinez!'
+
+    >>> all_calls = spy(inquisitors.surprise).all_calls
+
+    >>> locations = [call.args[0] for call in all_calls]
+    >>> interrogators = [call.kwargs.get("interrogator") for call in all_calls]
+
+    >>> assert locations == ["the village", "the castle", "the town square"]
+    >>> assert interrogators == ["Cardinal Biggles", "Cardinal Fang", "Cardinal Ximinez"]

--- a/mocksafe/apis/bdd/that.py
+++ b/mocksafe/apis/bdd/that.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Union, Any
+from typing import NamedTuple, Union, Any
 from mocksafe.core.custom_types import Call
 from mocksafe.core.spy import CallRecorder
 
@@ -141,3 +141,32 @@ class MockCalls:
         if kwargs:
             return call
         return args
+
+    @property
+    def all_calls(self: MockCalls) -> list[NamedCall]:
+        """
+        Returns a list of all calls made to the spied/mocked method.
+
+        Each call is represented as a NamedCall object.
+
+        :rtype: list[NamedCall]
+
+        :Example:
+            >>> when(mock_random.randint).any_call().then_return(5, 13)
+            >>> mock_random.randint(a=1, b=10)
+            5
+            >>> mock_random.randint(10, 20)
+            13
+            >>> spy(mock_random.randint).all_calls
+            [NamedCall(args=(), kwargs={'a': 1, 'b': 10}), NamedCall(args=...)]
+        """
+        return [NamedCall(args, kwargs) for args, kwargs in self._call_recorder.calls]
+
+
+class NamedCall(NamedTuple):
+    """
+    Details of a call made to a mocked/spied method.
+    """
+
+    args: tuple
+    kwargs: dict[str, Any]


### PR DESCRIPTION
* Resolves #57

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--66.org.readthedocs.build/en/66/

<!-- readthedocs-preview mocksafe end -->