### PR TITLE
Fix build failures in main

### DIFF
--- a/mocksafe/core/spy.py
+++ b/mocksafe/core/spy.py
@@ -4,11 +4,11 @@ from typing import Generic, Optional, TypeVar, Protocol, runtime_checkable
 from mocksafe.core.custom_types import MethodName, Call
 from mocksafe.core.call_type_validator import CallTypeValidator
 
-T = TypeVar("T", covariant=True)
+T_co = TypeVar("T_co", covariant=True)
 
 
-class Delegate(Protocol[T]):
-    def __call__(self, *args, **kwargs) -> Optional[T]: ...
+class Delegate(Protocol[T_co]):
+    def __call__(self, *args, **kwargs) -> Optional[T_co]: ...
 
 
 @runtime_checkable
@@ -27,7 +27,7 @@ class CallRecorder(Protocol):
     def nth_call(self, n: int) -> Call: ...
 
 
-class MethodSpy(CallRecorder, Generic[T]):
+class MethodSpy(CallRecorder, Generic[T_co]):
     def __init__(
         self: MethodSpy,
         name: MethodName,
@@ -39,7 +39,7 @@ class MethodSpy(CallRecorder, Generic[T]):
         self._calls: list[Call] = []
         self._signature = signature
 
-    def __call__(self: MethodSpy, *args, **kwargs) -> Optional[T]:
+    def __call__(self: MethodSpy, *args, **kwargs) -> Optional[T_co]:
         validator = CallTypeValidator(
             self._name,
             self._signature.parameters,

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 # Align with black
 max-line-length = 88
 
-ignore = RST304, ANN002, ANN003, ANN101, ANN204, ANN401
+ignore = RST304, ANN002, ANN003, ANN101, ANN204, ANN401, E704
 
 per-file-ignores =
     # Ignore F401 'imported but unused' in __init__.py files
@@ -83,7 +83,7 @@ per-file-ignores =
 description = build sphinx docs
 changedir = docs
 deps =
-    sphinx>=8.1.0
+    sphinx>=7.0.0,<8.0.0
     .[docs]
 commands =
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
This PR fixes the build failures reported in issue #81.

## Changes Made

1. **Fixed lint errors (E704)**: Added E704 to flake8 ignore list to allow ellipsis notation on the same line as Protocol method definitions, which is Black's preferred formatting.

2. **Fixed Sphinx compatibility**: Updated Sphinx version constraint from >=8.1.0 to >=7.0.0,<8.0.0 to maintain compatibility with Python 3.9. Sphinx 8.0+ dropped Python 3.9 support.

3. **Fixed TypeVar naming convention (N808)**: Renamed TypeVar from  to  to follow the CapWords convention with covariance suffix as required by flake8.

## Testing

All tox environments now pass:
- format ✅
- lint ✅ 
- mypy ✅
- pyright ✅
- py39, py310, py311, py312, py313 ✅
- docs ✅

## Addresses Issue Recommendations

This PR also addresses the issue's suggestion to reduce discrepancy between main and PR workflows by ensuring the build configuration works consistently across all Python versions tested.

Fixes #81

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview mocksafe end -->