### PR TITLE
Release v0.10.0-beta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@
     :target: https://github.com/dmayo3/mocksafe/blob/main/LICENSE
     :alt: MIT License
 
-MockSafe v0.9.0-beta
+MockSafe v0.10.0-beta
 ---------------------
 
 A mocking library developed to enable static and runtime type checking of your mocks to help keep them up-to-date with your production code.

--- a/mocksafe/__init__.py
+++ b/mocksafe/__init__.py
@@ -31,7 +31,7 @@ from mocksafe.apis.bdd import (
     spy,
 )
 
-__version__ = "0.9.0-beta"
+__version__ = "0.10.0-beta"
 
 __all__ = [
     "MockProperty",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mocksafe"
-version = "0.9.0-beta"
+version = "0.10.0-beta"
 
 description = "A mocking library developed to enable static and runtime type checking of your mocks to keep them in sync with production code."
 
@@ -79,7 +79,7 @@ requires = ["setuptools", "wheel"]
 mocksafe = "mocksafe.plugin"
 
 [tool.bumpver]
-current_version = "0.9.0-beta"
+current_version = "0.10.0-beta"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
This PR implements the version bump for v0.10.0-beta as outlined in issue #90.

Changes:
- Bump version from 0.9.0-beta to 0.10.0-beta in README.rst, mocksafe/__init__.py, and pyproject.toml
- Ready for GitHub Actions checks and review

Closes #90