### PR TITLE
Set git identity before annotated release tag creation

### DIFF
--- a/.github/actions/auto-tag-release/create-tag.sh
+++ b/.github/actions/auto-tag-release/create-tag.sh
@@ -5,6 +5,9 @@ VERSION="${VERSION:?}"
 
 TAG_NAME="${VERSION}"
 
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
 echo "🏷️  Creating annotated tag: ${TAG_NAME}"
 git tag -a "${TAG_NAME}" -m "Release ${TAG_NAME}" || {
   echo "❌ Failed to create tag ${TAG_NAME}"


### PR DESCRIPTION
## Summary
- configure git user.name and user.email in auto-tag create script before creating annotated tag

## Why
Dry-run release still failed in Auto-Tag Release after executable-bit fix because annotated tag creation requires git identity.

Failure from run 24450734686:
- Committer identity unknown
- fatal: empty ident name

## Validation
- reproduced failure in release workflow dry-run run 24450734686
- validated shell syntax for updated script

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--153.org.readthedocs.build/en/153/

<!-- readthedocs-preview mocksafe end -->