### PR TITLE
Explicitly dispatch publish workflow on tag and propagate dry-run

### DIFF
--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -22,7 +22,7 @@ outputs:
     value: ${{ steps.push-tag.outputs.pushed }}
   workflow_run_url:
     description: URL to the triggered publish workflow run
-    value: ${{ inputs.dry_run == 'true' && steps.dispatch-publish-dry-run.outputs.run_url || '' }}
+    value: ${{ steps.dispatch-publish.outputs.run_url }}
   cleanup_status:
     description: Status of dry-run cleanup
     value: ${{ steps.cleanup.outputs.status }}
@@ -44,25 +44,14 @@ runs:
         VERSION: ${{ inputs.version }}
       run: ${{ github.action_path }}/push-tag.sh
 
-    - name: Dispatch and wait for dry-run publish workflow
-      id: dispatch-publish-dry-run
-      if: ${{ inputs.dry_run == 'true' }}
+    - name: Dispatch publish workflow
+      id: dispatch-publish
       uses: ./.github/actions/dispatch-publish-workflow
       with:
         ref: ${{ steps.create-tag.outputs.tag_name }}
-        dry_run: "true"
+        dry_run: ${{ inputs.dry_run == 'true' && 'true' || 'false' }}
+        wait_for_completion: ${{ inputs.dry_run == 'true' && 'true' || 'false' }}
         github_token: ${{ inputs.github_token }}
-
-    - name: Dispatch publish workflow
-      if: ${{ inputs.dry_run != 'true' }}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-        TAG_NAME: ${{ steps.create-tag.outputs.tag_name }}
-      run: |
-        echo "🚀 Dispatching publish workflow on ref ${TAG_NAME}..."
-        gh workflow run publish.yaml --ref "${TAG_NAME}" --field dry_run=false
-        echo "✅ Publish workflow dispatch requested"
 
     - name: Dry-run cleanup
       id: cleanup

--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -50,7 +50,7 @@ runs:
       with:
         ref: ${{ steps.create-tag.outputs.tag_name }}
         dry_run: ${{ inputs.dry_run == 'true' && 'true' || 'false' }}
-        wait_for_completion: ${{ inputs.dry_run == 'true' && 'true' || 'false' }}
+        wait_for_completion: "true"
         github_token: ${{ inputs.github_token }}
 
     - name: Dry-run cleanup
@@ -67,9 +67,13 @@ runs:
       shell: bash
       env:
         TAG: ${{ steps.create-tag.outputs.tag_name }}
+        RUN_URL: ${{ steps.dispatch-publish.outputs.run_url }}
       run: |
         echo "✅ Tag ${TAG} created and pushed"
-        echo "📢 Publish workflow dispatch requested on ref ${TAG}"
+        echo "✅ Publish workflow completed successfully"
+        if [ -n "$RUN_URL" ]; then
+          echo "📢 Publish workflow: $RUN_URL"
+        fi
 
     - name: Dry-run summary
       if: inputs.dry_run == 'true'

--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -22,7 +22,7 @@ outputs:
     value: ${{ steps.push-tag.outputs.pushed }}
   workflow_run_url:
     description: URL to the triggered publish workflow run
-    value: ${{ steps.push-tag.outputs.run_url }}
+    value: ${{ inputs.dry_run == 'true' && steps.dispatch-publish-dry-run.outputs.run_url || '' }}
   cleanup_status:
     description: Status of dry-run cleanup
     value: ${{ steps.cleanup.outputs.status }}
@@ -37,14 +37,32 @@ runs:
         VERSION: ${{ inputs.version }}
       run: ${{ github.action_path }}/create-tag.sh
 
-    - name: Push tag and dispatch publish workflow
+    - name: Push tag
       id: push-tag
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
-        GH_TOKEN: ${{ inputs.github_token }}
-        DRY_RUN: ${{ inputs.dry_run }}
       run: ${{ github.action_path }}/push-tag.sh
+
+    - name: Dispatch and wait for dry-run publish workflow
+      id: dispatch-publish-dry-run
+      if: ${{ inputs.dry_run == 'true' }}
+      uses: ./.github/actions/dispatch-publish-workflow
+      with:
+        ref: ${{ steps.create-tag.outputs.tag_name }}
+        dry_run: "true"
+        github_token: ${{ inputs.github_token }}
+
+    - name: Dispatch publish workflow
+      if: ${{ inputs.dry_run != 'true' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        TAG_NAME: ${{ steps.create-tag.outputs.tag_name }}
+      run: |
+        echo "🚀 Dispatching publish workflow on ref ${TAG_NAME}..."
+        gh workflow run publish.yaml --ref "${TAG_NAME}" --field dry_run=false
+        echo "✅ Publish workflow dispatch requested"
 
     - name: Dry-run cleanup
       id: cleanup
@@ -52,7 +70,6 @@ runs:
       shell: bash
       env:
         TAG_NAME: ${{ steps.create-tag.outputs.tag_name }}
-        RUN_ID: ${{ steps.push-tag.outputs.run_id }}
         GH_TOKEN: ${{ inputs.github_token }}
       run: ${{ github.action_path }}/cleanup.sh
 
@@ -61,12 +78,9 @@ runs:
       shell: bash
       env:
         TAG: ${{ steps.create-tag.outputs.tag_name }}
-        RUN_URL: ${{ steps.push-tag.outputs.run_url }}
       run: |
         echo "✅ Tag ${TAG} created and pushed"
-        if [ -n "$RUN_URL" ]; then
-          echo "📢 Publish workflow: $RUN_URL"
-        fi
+        echo "📢 Publish workflow dispatch requested on ref ${TAG}"
 
     - name: Dry-run summary
       if: inputs.dry_run == 'true'

--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Dry-run cleanup
       id: cleanup
-      if: inputs.dry_run == 'true'
+      if: ${{ always() && inputs.dry_run == 'true' }}
       shell: bash
       env:
         TAG_NAME: ${{ steps.create-tag.outputs.tag_name }}

--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -1,12 +1,12 @@
 name: Auto-Tag Release
-description: Create git tag and push to trigger publish workflow
+description: Create git tag, dispatch publish workflow, and validate dry-run behavior
 
 inputs:
   version:
     description: Version to tag (e.g., "1.2.3" or "1.2.3-beta")
     required: true
   dry_run:
-    description: If true, cancel triggered workflow and clean up tag after testing
+    description: If true, wait for publish workflow success, then clean up tag
     required: false
     default: "true"
   github_token:
@@ -37,7 +37,7 @@ runs:
         VERSION: ${{ inputs.version }}
       run: ${{ github.action_path }}/create-tag.sh
 
-    - name: Push tag and find workflow
+    - name: Push tag and dispatch publish workflow
       id: push-tag
       shell: bash
       env:
@@ -48,7 +48,7 @@ runs:
 
     - name: Dry-run cleanup
       id: cleanup
-      if: ${{ always() && inputs.dry_run == 'true' }}
+      if: ${{ always() && inputs.dry_run == 'true' && steps.create-tag.outputs.tag_name != '' }}
       shell: bash
       env:
         TAG_NAME: ${{ steps.create-tag.outputs.tag_name }}
@@ -74,4 +74,4 @@ runs:
       env:
         TAG: ${{ steps.create-tag.outputs.tag_name }}
       run: |
-        echo "✅ Dry-run completed - tag $TAG was created, tested, and cleaned up"
+        echo "✅ Dry-run completed - publish workflow succeeded and tag $TAG was cleaned up"

--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -50,7 +50,6 @@ runs:
       with:
         ref: ${{ steps.create-tag.outputs.tag_name }}
         dry_run: ${{ inputs.dry_run == 'true' && 'true' || 'false' }}
-        wait_for_completion: "true"
         github_token: ${{ inputs.github_token }}
 
     - name: Dry-run cleanup

--- a/.github/actions/auto-tag-release/action.yml
+++ b/.github/actions/auto-tag-release/action.yml
@@ -43,6 +43,7 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ inputs.github_token }}
+        DRY_RUN: ${{ inputs.dry_run }}
       run: ${{ github.action_path }}/push-tag.sh
 
     - name: Dry-run cleanup

--- a/.github/actions/auto-tag-release/cleanup.sh
+++ b/.github/actions/auto-tag-release/cleanup.sh
@@ -3,31 +3,35 @@ set -euo pipefail
 
 TAG_NAME="${TAG_NAME:?}"
 GH_TOKEN="${GH_TOKEN:?}"
+RUN_ID="${RUN_ID:-}"
 
 echo "🧪 DRY RUN MODE - Starting cleanup"
 echo ""
 
-# Wait for the workflow run to appear (max 90 seconds)
-echo "⏳ Waiting for publish workflow to start (up to 90 seconds)..."
-MAX_WAIT=90
-INTERVAL=3
-ELAPSED=0
-RUN_ID=""
+# Use provided workflow run when available; otherwise discover it (max 90 seconds)
+if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
+  echo "✅ Using provided publish workflow run: $RUN_ID"
+else
+  echo "⏳ Waiting for publish workflow to start (up to 90 seconds)..."
+  MAX_WAIT=90
+  INTERVAL=3
+  ELAPSED=0
 
-while [ $ELAPSED -lt $MAX_WAIT ]; do
-  RUN_ID=$(gh run list \
-    --workflow publish.yaml \
-    --json databaseId,status \
-    --jq '.[0].databaseId' 2>/dev/null || echo "")
+  while [ $ELAPSED -lt $MAX_WAIT ]; do
+    RUN_ID=$(gh run list \
+      --workflow publish.yaml \
+      --json databaseId,status \
+      --jq '.[0].databaseId' 2>/dev/null || echo "")
 
-  if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
-    echo "✅ Found publish workflow run: $RUN_ID"
-    break
-  fi
+    if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
+      echo "✅ Found publish workflow run: $RUN_ID"
+      break
+    fi
 
-  sleep $INTERVAL
-  ELAPSED=$((ELAPSED + INTERVAL))
-done
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+fi
 
 if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
   echo "⏳ Waiting 30 seconds for workflow jobs to initialize..."
@@ -40,7 +44,8 @@ if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
     echo "⚠️  Could not cancel workflow (may have already completed)"
   fi
 else
-  echo "⚠️  Could not find workflow run (cleanup will continue)"
+  echo "❌ Could not find publish workflow run for cleanup"
+  exit 1
 fi
 
 echo ""

--- a/.github/actions/auto-tag-release/cleanup.sh
+++ b/.github/actions/auto-tag-release/cleanup.sh
@@ -3,28 +3,8 @@ set -euo pipefail
 
 TAG_NAME="${TAG_NAME:?}"
 GH_TOKEN="${GH_TOKEN:?}"
-RUN_ID="${RUN_ID:-}"
 
 echo "🧪 DRY RUN MODE - Starting cleanup"
-echo ""
-
-# Require provided workflow run id from the push step
-if [[ -z "$RUN_ID" ]] || [[ "$RUN_ID" == "null" ]]; then
-  echo "❌ Missing publish workflow run id for cleanup"
-  exit 1
-fi
-
-echo "✅ Using provided publish workflow run: $RUN_ID"
-echo "⏳ Waiting 30 seconds for workflow jobs to initialize..."
-sleep 30
-
-echo "🛑 Canceling workflow run..."
-if gh run cancel "$RUN_ID"; then
-  echo "✅ Workflow canceled"
-else
-  echo "⚠️  Could not cancel workflow (may have already completed)"
-fi
-
 echo ""
 echo "🧹 Deleting tag ${TAG_NAME}..."
 if git tag -d "$TAG_NAME" 2>/dev/null && git push origin --delete "$TAG_NAME" 2>/dev/null; then

--- a/.github/actions/auto-tag-release/cleanup.sh
+++ b/.github/actions/auto-tag-release/cleanup.sh
@@ -8,44 +8,21 @@ RUN_ID="${RUN_ID:-}"
 echo "🧪 DRY RUN MODE - Starting cleanup"
 echo ""
 
-# Use provided workflow run when available; otherwise discover it (max 90 seconds)
-if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
-  echo "✅ Using provided publish workflow run: $RUN_ID"
-else
-  echo "⏳ Waiting for publish workflow to start (up to 90 seconds)..."
-  MAX_WAIT=90
-  INTERVAL=3
-  ELAPSED=0
-
-  while [ $ELAPSED -lt $MAX_WAIT ]; do
-    RUN_ID=$(gh run list \
-      --workflow publish.yaml \
-      --json databaseId,status \
-      --jq '.[0].databaseId' 2>/dev/null || echo "")
-
-    if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
-      echo "✅ Found publish workflow run: $RUN_ID"
-      break
-    fi
-
-    sleep $INTERVAL
-    ELAPSED=$((ELAPSED + INTERVAL))
-  done
+# Require provided workflow run id from the push step
+if [[ -z "$RUN_ID" ]] || [[ "$RUN_ID" == "null" ]]; then
+  echo "❌ Missing publish workflow run id for cleanup"
+  exit 1
 fi
 
-if [[ -n "$RUN_ID" ]] && [[ "$RUN_ID" != "null" ]]; then
-  echo "⏳ Waiting 30 seconds for workflow jobs to initialize..."
-  sleep 30
+echo "✅ Using provided publish workflow run: $RUN_ID"
+echo "⏳ Waiting 30 seconds for workflow jobs to initialize..."
+sleep 30
 
-  echo "🛑 Canceling workflow run..."
-  if gh run cancel "$RUN_ID"; then
-    echo "✅ Workflow canceled"
-  else
-    echo "⚠️  Could not cancel workflow (may have already completed)"
-  fi
+echo "🛑 Canceling workflow run..."
+if gh run cancel "$RUN_ID"; then
+  echo "✅ Workflow canceled"
 else
-  echo "❌ Could not find publish workflow run for cleanup"
-  exit 1
+  echo "⚠️  Could not cancel workflow (may have already completed)"
 fi
 
 echo ""

--- a/.github/actions/auto-tag-release/push-tag.sh
+++ b/.github/actions/auto-tag-release/push-tag.sh
@@ -50,6 +50,35 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
     REPO="${GITHUB_REPOSITORY}"
     RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
     echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
+
+    if [ "$DRY_RUN" = "true" ]; then
+      echo "⏳ Dry-run mode: waiting for publish workflow to complete successfully..."
+      RUN_WAIT_MAX=1800
+      RUN_WAIT_INTERVAL=10
+      RUN_WAIT_ELAPSED=0
+
+      while [ $RUN_WAIT_ELAPSED -lt $RUN_WAIT_MAX ]; do
+        RUN_STATUS=$(gh run view "$RUN_ID" --json status,conclusion -q '.status' 2>/dev/null || echo "")
+        RUN_CONCLUSION=$(gh run view "$RUN_ID" --json status,conclusion -q '.conclusion' 2>/dev/null || echo "")
+
+        if [ "$RUN_STATUS" = "completed" ]; then
+          if [ "$RUN_CONCLUSION" = "success" ]; then
+            echo "✅ Dry-run publish workflow completed successfully"
+            exit 0
+          fi
+
+          echo "❌ Dry-run publish workflow finished with conclusion: ${RUN_CONCLUSION}"
+          exit 1
+        fi
+
+        sleep $RUN_WAIT_INTERVAL
+        RUN_WAIT_ELAPSED=$((RUN_WAIT_ELAPSED + RUN_WAIT_INTERVAL))
+      done
+
+      echo "❌ Timed out waiting for dry-run publish workflow completion (${RUN_WAIT_MAX}s)"
+      exit 1
+    fi
+
     exit 0
   fi
 

--- a/.github/actions/auto-tag-release/push-tag.sh
+++ b/.github/actions/auto-tag-release/push-tag.sh
@@ -2,9 +2,6 @@
 set -euo pipefail
 
 VERSION="${VERSION:?}"
-GH_TOKEN="${GH_TOKEN:?}"
-DRY_RUN="${DRY_RUN:-false}"
-
 TAG_NAME="${VERSION}"
 
 echo "🚀 Pushing tag to origin..."
@@ -18,73 +15,5 @@ else
 fi
 
 echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
-
-echo "🚀 Triggering publish workflow explicitly on tag ref: ${TAG_NAME} (dry_run=${DRY_RUN})..."
-
-if gh workflow run publish.yaml --ref "${TAG_NAME}" --field dry_run="${DRY_RUN}"; then
-  echo "✅ Publish workflow dispatch requested for ref ${TAG_NAME} (dry_run=${DRY_RUN})"
-else
-  echo "❌ Failed to dispatch publish workflow for ref ${TAG_NAME}"
-  exit 1
-fi
-
-echo "⏳ Waiting for publish workflow run to appear..."
-
-MAX_WAIT=90
-INTERVAL=3
-ELAPSED=0
-RUN_ID=""
-
-while [ $ELAPSED -lt $MAX_WAIT ]; do
-  RUN_ID=$(gh run list \
-    --workflow publish.yaml \
-    --status in_progress,queued \
-    --json databaseId,createdAt \
-    --limit 1 \
-    -q '.[0].databaseId' 2>/dev/null || echo "")
-
-  if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
-    echo "✅ Found publish workflow run: ${RUN_ID}"
-    echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-
-    REPO="${GITHUB_REPOSITORY}"
-    RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
-    echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
-
-    if [ "$DRY_RUN" = "true" ]; then
-      echo "⏳ Dry-run mode: waiting for publish workflow to complete successfully..."
-      RUN_WAIT_MAX=1800
-      RUN_WAIT_INTERVAL=10
-      RUN_WAIT_ELAPSED=0
-
-      while [ $RUN_WAIT_ELAPSED -lt $RUN_WAIT_MAX ]; do
-        RUN_STATUS=$(gh run view "$RUN_ID" --json status,conclusion -q '.status' 2>/dev/null || echo "")
-        RUN_CONCLUSION=$(gh run view "$RUN_ID" --json status,conclusion -q '.conclusion' 2>/dev/null || echo "")
-
-        if [ "$RUN_STATUS" = "completed" ]; then
-          if [ "$RUN_CONCLUSION" = "success" ]; then
-            echo "✅ Dry-run publish workflow completed successfully"
-            exit 0
-          fi
-
-          echo "❌ Dry-run publish workflow finished with conclusion: ${RUN_CONCLUSION}"
-          exit 1
-        fi
-
-        sleep $RUN_WAIT_INTERVAL
-        RUN_WAIT_ELAPSED=$((RUN_WAIT_ELAPSED + RUN_WAIT_INTERVAL))
-      done
-
-      echo "❌ Timed out waiting for dry-run publish workflow completion (${RUN_WAIT_MAX}s)"
-      exit 1
-    fi
-
-    exit 0
-  fi
-
-  sleep $INTERVAL
-  ELAPSED=$((ELAPSED + INTERVAL))
-done
-
-echo "❌ Could not locate the dispatched publish workflow run within ${MAX_WAIT}s"
-exit 1
+echo "run_id=" >> "$GITHUB_OUTPUT"
+echo "run_url=" >> "$GITHUB_OUTPUT"

--- a/.github/actions/auto-tag-release/push-tag.sh
+++ b/.github/actions/auto-tag-release/push-tag.sh
@@ -57,6 +57,5 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
   ELAPSED=$((ELAPSED + INTERVAL))
 done
 
-echo "⚠️  Could not locate the dispatched publish workflow run"
-echo "run_id=" >> "$GITHUB_OUTPUT"
-echo "run_url=" >> "$GITHUB_OUTPUT"
+echo "❌ Could not locate the dispatched publish workflow run within ${MAX_WAIT}s"
+exit 1

--- a/.github/actions/auto-tag-release/push-tag.sh
+++ b/.github/actions/auto-tag-release/push-tag.sh
@@ -53,6 +53,47 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
   ELAPSED=$((ELAPSED + INTERVAL))
 done
 
-echo "⚠️  Could not locate the triggered workflow run"
+echo "⚠️  Could not locate the triggered workflow run from tag push"
+echo "🔁 Falling back to manual publish workflow dispatch..."
+
+if gh workflow run publish.yaml --ref main; then
+  echo "✅ Manual publish workflow dispatch requested"
+else
+  echo "⚠️  Failed to dispatch publish workflow manually"
+  echo "run_id=" >> "$GITHUB_OUTPUT"
+  echo "run_url=" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "⏳ Waiting for manually dispatched publish workflow to appear..."
+
+MAX_WAIT=90
+INTERVAL=3
+ELAPSED=0
+RUN_ID=""
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  RUN_ID=$(gh run list \
+    --workflow publish.yaml \
+    --status in_progress,queued \
+    --json databaseId,createdAt \
+    --limit 1 \
+    -q '.[0].databaseId' 2>/dev/null || echo "")
+
+  if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+    echo "✅ Found manually dispatched publish workflow run: ${RUN_ID}"
+    echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+    REPO="${GITHUB_REPOSITORY}"
+    RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+    echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "⚠️  Could not locate the manually dispatched workflow run"
 echo "run_id=" >> "$GITHUB_OUTPUT"
 echo "run_url=" >> "$GITHUB_OUTPUT"

--- a/.github/actions/auto-tag-release/push-tag.sh
+++ b/.github/actions/auto-tag-release/push-tag.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 VERSION="${VERSION:?}"
 GH_TOKEN="${GH_TOKEN:?}"
+DRY_RUN="${DRY_RUN:-false}"
 
 TAG_NAME="${VERSION}"
 
@@ -18,19 +19,23 @@ fi
 
 echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
-echo "⏳ Waiting for publish workflow to be triggered..."
+echo "🚀 Triggering publish workflow explicitly on tag ref: ${TAG_NAME} (dry_run=${DRY_RUN})..."
 
-# Give GitHub a moment to register the tag push
-sleep 5
+if gh workflow run publish.yaml --ref "${TAG_NAME}" --field dry_run="${DRY_RUN}"; then
+  echo "✅ Publish workflow dispatch requested for ref ${TAG_NAME} (dry_run=${DRY_RUN})"
+else
+  echo "❌ Failed to dispatch publish workflow for ref ${TAG_NAME}"
+  exit 1
+fi
 
-# Wait up to 90 seconds for the workflow to appear
+echo "⏳ Waiting for publish workflow run to appear..."
+
 MAX_WAIT=90
 INTERVAL=3
 ELAPSED=0
 RUN_ID=""
 
 while [ $ELAPSED -lt $MAX_WAIT ]; do
-  # Look for the most recent publish.yaml workflow run
   RUN_ID=$(gh run list \
     --workflow publish.yaml \
     --status in_progress,queued \
@@ -42,7 +47,6 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
     echo "✅ Found publish workflow run: ${RUN_ID}"
     echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
-    # Generate URL to the workflow run
     REPO="${GITHUB_REPOSITORY}"
     RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
     echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
@@ -53,47 +57,6 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
   ELAPSED=$((ELAPSED + INTERVAL))
 done
 
-echo "⚠️  Could not locate the triggered workflow run from tag push"
-echo "🔁 Falling back to manual publish workflow dispatch..."
-
-if gh workflow run publish.yaml --ref main; then
-  echo "✅ Manual publish workflow dispatch requested"
-else
-  echo "⚠️  Failed to dispatch publish workflow manually"
-  echo "run_id=" >> "$GITHUB_OUTPUT"
-  echo "run_url=" >> "$GITHUB_OUTPUT"
-  exit 0
-fi
-
-echo "⏳ Waiting for manually dispatched publish workflow to appear..."
-
-MAX_WAIT=90
-INTERVAL=3
-ELAPSED=0
-RUN_ID=""
-
-while [ $ELAPSED -lt $MAX_WAIT ]; do
-  RUN_ID=$(gh run list \
-    --workflow publish.yaml \
-    --status in_progress,queued \
-    --json databaseId,createdAt \
-    --limit 1 \
-    -q '.[0].databaseId' 2>/dev/null || echo "")
-
-  if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
-    echo "✅ Found manually dispatched publish workflow run: ${RUN_ID}"
-    echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-
-    REPO="${GITHUB_REPOSITORY}"
-    RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
-    echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
-    exit 0
-  fi
-
-  sleep $INTERVAL
-  ELAPSED=$((ELAPSED + INTERVAL))
-done
-
-echo "⚠️  Could not locate the manually dispatched workflow run"
+echo "⚠️  Could not locate the dispatched publish workflow run"
 echo "run_id=" >> "$GITHUB_OUTPUT"
 echo "run_url=" >> "$GITHUB_OUTPUT"

--- a/.github/actions/dispatch-publish-workflow/action.yml
+++ b/.github/actions/dispatch-publish-workflow/action.yml
@@ -41,18 +41,14 @@ runs:
   using: composite
   steps:
     - name: Dispatch publish workflow
+      id: dispatch
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         REF: ${{ inputs.ref }}
         DRY_RUN: ${{ inputs.dry_run }}
         WORKFLOW_FILE: ${{ inputs.workflow_file }}
-      run: |
-        set -euo pipefail
-
-        echo "🚀 Dispatching ${WORKFLOW_FILE} on ref ${REF} (dry_run=${DRY_RUN})..."
-        gh workflow run "${WORKFLOW_FILE}" --ref "${REF}" --field dry_run="${DRY_RUN}"
-        echo "✅ Dispatch requested"
+      run: bash ${{ github.action_path }}/dispatch-workflow.sh
 
     - name: Discover dispatched run
       id: discover
@@ -63,39 +59,7 @@ runs:
         WORKFLOW_FILE: ${{ inputs.workflow_file }}
         DISCOVER_TIMEOUT_SECONDS: ${{ inputs.discover_timeout_seconds }}
         POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
-      run: |
-        set -euo pipefail
-
-        elapsed=0
-        run_id=""
-
-        echo "⏳ Waiting for dispatched workflow run to appear..."
-
-        while [ "$elapsed" -lt "$DISCOVER_TIMEOUT_SECONDS" ]; do
-          run_id="$(gh run list \
-            --workflow "${WORKFLOW_FILE}" \
-            --event workflow_dispatch \
-            --json databaseId,headBranch,createdAt \
-            --limit 50 \
-            --jq ".[] | select(.headBranch==\"${REF}\") | .databaseId" | head -n 1 || true)"
-
-          if [ -n "${run_id}" ] && [ "${run_id}" != "null" ]; then
-            break
-          fi
-
-          sleep "${POLL_INTERVAL_SECONDS}"
-          elapsed=$((elapsed + POLL_INTERVAL_SECONDS))
-        done
-
-        if [ -z "${run_id}" ] || [ "${run_id}" = "null" ]; then
-          echo "❌ Could not find dispatched workflow run for ref ${REF} within ${DISCOVER_TIMEOUT_SECONDS}s"
-          exit 1
-        fi
-
-        run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
-        echo "✅ Found workflow run: ${run_id}"
-        echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
-        echo "run_url=${run_url}" >> "${GITHUB_OUTPUT}"
+      run: bash ${{ github.action_path }}/discover-run.sh
 
     - name: Wait for workflow success
       id: wait
@@ -103,14 +67,5 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         RUN_ID: ${{ steps.discover.outputs.run_id }}
-
         POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
-      run: |
-        set -euo pipefail
-
-        echo "⏳ Waiting for run ${RUN_ID} to complete successfully..."
-        gh run watch "${RUN_ID}" --exit-status --interval "${POLL_INTERVAL_SECONDS}"
-
-        conclusion="$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion' || true)"
-        echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
-        echo "✅ Workflow completed successfully"
+      run: bash ${{ github.action_path }}/wait-for-run.sh

--- a/.github/actions/dispatch-publish-workflow/action.yml
+++ b/.github/actions/dispatch-publish-workflow/action.yml
@@ -1,5 +1,5 @@
 name: Dispatch Publish Workflow
-description: Dispatch publish workflow on a ref and wait for successful completion
+description: Dispatch publish workflow on a ref, with optional wait for successful completion
 
 inputs:
   ref:
@@ -24,6 +24,10 @@ inputs:
     description: Max seconds to wait for workflow run completion
     required: false
     default: "3600"
+  wait_for_completion:
+    description: Whether to wait for workflow completion and require success
+    required: false
+    default: "true"
   poll_interval_seconds:
     description: Poll interval in seconds while waiting
     required: false
@@ -37,8 +41,8 @@ outputs:
     description: URL of dispatched workflow run
     value: ${{ steps.discover.outputs.run_url }}
   conclusion:
-    description: Final workflow conclusion
-    value: ${{ steps.wait.outputs.conclusion }}
+    description: Final workflow conclusion (or "not_waited" when wait is disabled)
+    value: ${{ inputs.wait_for_completion == 'true' && steps.wait.outputs.conclusion || 'not_waited' }}
 
 runs:
   using: composite
@@ -102,6 +106,7 @@ runs:
 
     - name: Wait for workflow success
       id: wait
+      if: ${{ inputs.wait_for_completion == 'true' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/dispatch-publish-workflow/action.yml
+++ b/.github/actions/dispatch-publish-workflow/action.yml
@@ -20,10 +20,7 @@ inputs:
     description: Max seconds to wait for dispatched workflow run to appear
     required: false
     default: "120"
-  completion_timeout_seconds:
-    description: Max seconds to wait for workflow run completion
-    required: false
-    default: "3600"
+
   poll_interval_seconds:
     description: Poll interval in seconds while waiting
     required: false
@@ -106,35 +103,14 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         RUN_ID: ${{ steps.discover.outputs.run_id }}
-        COMPLETION_TIMEOUT_SECONDS: ${{ inputs.completion_timeout_seconds }}
+
         POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
       run: |
         set -euo pipefail
 
-        elapsed=0
-
         echo "⏳ Waiting for run ${RUN_ID} to complete successfully..."
+        gh run watch "${RUN_ID}" --exit-status --interval "${POLL_INTERVAL_SECONDS}"
 
-        while [ "$elapsed" -lt "$COMPLETION_TIMEOUT_SECONDS" ]; do
-          status="$(gh run view "${RUN_ID}" --json status,conclusion --jq '.status' || true)"
-          conclusion="$(gh run view "${RUN_ID}" --json status,conclusion --jq '.conclusion' || true)"
-
-          if [ "${status}" = "completed" ]; then
-            echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
-
-            if [ "${conclusion}" = "success" ]; then
-              echo "✅ Workflow completed successfully"
-              exit 0
-            fi
-
-            echo "❌ Workflow completed with conclusion: ${conclusion}"
-            exit 1
-          fi
-
-          sleep "${POLL_INTERVAL_SECONDS}"
-          elapsed=$((elapsed + POLL_INTERVAL_SECONDS))
-        done
-
-        echo "conclusion=timed_out" >> "${GITHUB_OUTPUT}"
-        echo "❌ Timed out waiting for workflow completion (${COMPLETION_TIMEOUT_SECONDS}s)"
-        exit 1
+        conclusion="$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion' || true)"
+        echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
+        echo "✅ Workflow completed successfully"

--- a/.github/actions/dispatch-publish-workflow/action.yml
+++ b/.github/actions/dispatch-publish-workflow/action.yml
@@ -1,0 +1,140 @@
+name: Dispatch Publish Workflow
+description: Dispatch publish workflow on a ref and wait for successful completion
+
+inputs:
+  ref:
+    description: Git ref to run publish workflow against (typically a tag like 0.11.0-beta)
+    required: true
+  dry_run:
+    description: Whether to run publish workflow in dry-run mode
+    required: false
+    default: "false"
+  github_token:
+    description: GitHub token for workflow dispatch and run inspection
+    required: true
+  workflow_file:
+    description: Workflow file name to dispatch
+    required: false
+    default: "publish.yaml"
+  discover_timeout_seconds:
+    description: Max seconds to wait for dispatched workflow run to appear
+    required: false
+    default: "120"
+  completion_timeout_seconds:
+    description: Max seconds to wait for workflow run completion
+    required: false
+    default: "3600"
+  poll_interval_seconds:
+    description: Poll interval in seconds while waiting
+    required: false
+    default: "5"
+
+outputs:
+  run_id:
+    description: Dispatched workflow run id
+    value: ${{ steps.discover.outputs.run_id }}
+  run_url:
+    description: URL of dispatched workflow run
+    value: ${{ steps.discover.outputs.run_url }}
+  conclusion:
+    description: Final workflow conclusion
+    value: ${{ steps.wait.outputs.conclusion }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch publish workflow
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REF: ${{ inputs.ref }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        WORKFLOW_FILE: ${{ inputs.workflow_file }}
+      run: |
+        set -euo pipefail
+
+        echo "🚀 Dispatching ${WORKFLOW_FILE} on ref ${REF} (dry_run=${DRY_RUN})..."
+        gh workflow run "${WORKFLOW_FILE}" --ref "${REF}" --field dry_run="${DRY_RUN}"
+        echo "✅ Dispatch requested"
+
+    - name: Discover dispatched run
+      id: discover
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REF: ${{ inputs.ref }}
+        WORKFLOW_FILE: ${{ inputs.workflow_file }}
+        DISCOVER_TIMEOUT_SECONDS: ${{ inputs.discover_timeout_seconds }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
+      run: |
+        set -euo pipefail
+
+        elapsed=0
+        run_id=""
+
+        echo "⏳ Waiting for dispatched workflow run to appear..."
+
+        while [ "$elapsed" -lt "$DISCOVER_TIMEOUT_SECONDS" ]; do
+          run_id="$(gh run list \
+            --workflow "${WORKFLOW_FILE}" \
+            --event workflow_dispatch \
+            --json databaseId,headBranch,createdAt \
+            --limit 50 \
+            --jq ".[] | select(.headBranch==\"${REF}\") | .databaseId" | head -n 1 || true)"
+
+          if [ -n "${run_id}" ] && [ "${run_id}" != "null" ]; then
+            break
+          fi
+
+          sleep "${POLL_INTERVAL_SECONDS}"
+          elapsed=$((elapsed + POLL_INTERVAL_SECONDS))
+        done
+
+        if [ -z "${run_id}" ] || [ "${run_id}" = "null" ]; then
+          echo "❌ Could not find dispatched workflow run for ref ${REF} within ${DISCOVER_TIMEOUT_SECONDS}s"
+          exit 1
+        fi
+
+        run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+        echo "✅ Found workflow run: ${run_id}"
+        echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+        echo "run_url=${run_url}" >> "${GITHUB_OUTPUT}"
+
+    - name: Wait for workflow success
+      id: wait
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        RUN_ID: ${{ steps.discover.outputs.run_id }}
+        COMPLETION_TIMEOUT_SECONDS: ${{ inputs.completion_timeout_seconds }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
+      run: |
+        set -euo pipefail
+
+        elapsed=0
+
+        echo "⏳ Waiting for run ${RUN_ID} to complete successfully..."
+
+        while [ "$elapsed" -lt "$COMPLETION_TIMEOUT_SECONDS" ]; do
+          status="$(gh run view "${RUN_ID}" --json status,conclusion --jq '.status' || true)"
+          conclusion="$(gh run view "${RUN_ID}" --json status,conclusion --jq '.conclusion' || true)"
+
+          if [ "${status}" = "completed" ]; then
+            echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
+
+            if [ "${conclusion}" = "success" ]; then
+              echo "✅ Workflow completed successfully"
+              exit 0
+            fi
+
+            echo "❌ Workflow completed with conclusion: ${conclusion}"
+            exit 1
+          fi
+
+          sleep "${POLL_INTERVAL_SECONDS}"
+          elapsed=$((elapsed + POLL_INTERVAL_SECONDS))
+        done
+
+        echo "conclusion=timed_out" >> "${GITHUB_OUTPUT}"
+        echo "❌ Timed out waiting for workflow completion (${COMPLETION_TIMEOUT_SECONDS}s)"
+        exit 1

--- a/.github/actions/dispatch-publish-workflow/action.yml
+++ b/.github/actions/dispatch-publish-workflow/action.yml
@@ -1,5 +1,5 @@
 name: Dispatch Publish Workflow
-description: Dispatch publish workflow on a ref, with optional wait for successful completion
+description: Dispatch publish workflow on a ref and wait for successful completion
 
 inputs:
   ref:
@@ -24,10 +24,6 @@ inputs:
     description: Max seconds to wait for workflow run completion
     required: false
     default: "3600"
-  wait_for_completion:
-    description: Whether to wait for workflow completion and require success
-    required: false
-    default: "true"
   poll_interval_seconds:
     description: Poll interval in seconds while waiting
     required: false
@@ -41,8 +37,8 @@ outputs:
     description: URL of dispatched workflow run
     value: ${{ steps.discover.outputs.run_url }}
   conclusion:
-    description: Final workflow conclusion (or "not_waited" when wait is disabled)
-    value: ${{ inputs.wait_for_completion == 'true' && steps.wait.outputs.conclusion || 'not_waited' }}
+    description: Final workflow conclusion
+    value: ${{ steps.wait.outputs.conclusion }}
 
 runs:
   using: composite
@@ -106,7 +102,6 @@ runs:
 
     - name: Wait for workflow success
       id: wait
-      if: ${{ inputs.wait_for_completion == 'true' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/dispatch-publish-workflow/discover-run.sh
+++ b/.github/actions/dispatch-publish-workflow/discover-run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REF="${REF:?REF is required}"
+WORKFLOW_FILE="${WORKFLOW_FILE:-publish.yaml}"
+DISCOVER_TIMEOUT_SECONDS="${DISCOVER_TIMEOUT_SECONDS:-120}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+
+elapsed=0
+run_id=""
+
+echo "⏳ Waiting for dispatched workflow run to appear for ref ${REF}..."
+
+while [ "$elapsed" -lt "$DISCOVER_TIMEOUT_SECONDS" ]; do
+  run_id="$(gh run list \
+    --workflow "${WORKFLOW_FILE}" \
+    --event workflow_dispatch \
+    --json databaseId,headBranch,createdAt \
+    --limit 50 \
+    --jq ".[] | select(.headBranch==\"${REF}\") | .databaseId" | head -n 1 || true)"
+
+  if [ -n "${run_id}" ] && [ "${run_id}" != "null" ]; then
+    break
+  fi
+
+  sleep "${POLL_INTERVAL_SECONDS}"
+  elapsed=$((elapsed + POLL_INTERVAL_SECONDS))
+done
+
+if [ -z "${run_id}" ] || [ "${run_id}" = "null" ]; then
+  echo "❌ Could not find dispatched workflow run for ref ${REF} within ${DISCOVER_TIMEOUT_SECONDS}s"
+  exit 1
+fi
+
+run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+echo "✅ Found workflow run: ${run_id}"
+
+echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+echo "run_url=${run_url}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/dispatch-publish-workflow/dispatch-workflow.sh
+++ b/.github/actions/dispatch-publish-workflow/dispatch-workflow.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GH_TOKEN="${GH_TOKEN:?GH_TOKEN is required}"
+REF="${REF:?REF is required}"
+WORKFLOW_FILE="${WORKFLOW_FILE:-publish.yaml}"
+DRY_RUN="${DRY_RUN:-false}"
+
+echo "🚀 Dispatching ${WORKFLOW_FILE} on ref ${REF} (dry_run=${DRY_RUN})..."
+gh workflow run "${WORKFLOW_FILE}" --ref "${REF}" --field dry_run="${DRY_RUN}"
+echo "✅ Dispatch requested"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "dispatch_requested=true" >> "${GITHUB_OUTPUT}"
+  echo "workflow_file=${WORKFLOW_FILE}" >> "${GITHUB_OUTPUT}"
+  echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
+  echo "dry_run=${DRY_RUN}" >> "${GITHUB_OUTPUT}"
+fi

--- a/.github/actions/dispatch-publish-workflow/wait-for-run.sh
+++ b/.github/actions/dispatch-publish-workflow/wait-for-run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ID="${RUN_ID:?RUN_ID is required}"
+GH_TOKEN="${GH_TOKEN:?GH_TOKEN is required}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+
+echo "⏳ Waiting for run ${RUN_ID} to complete successfully..."
+gh run watch "${RUN_ID}" --exit-status --interval "${POLL_INTERVAL_SECONDS}"
+
+conclusion="$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion' || true)"
+if [ -z "${conclusion}" ] || [ "${conclusion}" = "null" ]; then
+  conclusion="unknown"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
+fi
+
+echo "✅ Workflow completed successfully (conclusion=${conclusion})"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,12 @@
 name: Publish to PyPI / TestPyPi
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip upload jobs (build/verify only)"
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - "0.*"
@@ -78,6 +84,7 @@ jobs:
     needs:
       - build
       - verify-dist
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read
       id-token: write # Required for trusted publishing
@@ -101,6 +108,7 @@ jobs:
     needs:
       - build
       - verify-dist
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read
       id-token: write # Required for trusted publishing

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,7 @@ jobs:
     needs:
       - build
       - verify-dist
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
+    if: ${{ github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read
       id-token: write # Required for trusted publishing
@@ -108,7 +108,7 @@ jobs:
     needs:
       - build
       - verify-dist
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
+    if: ${{ github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read
       id-token: write # Required for trusted publishing


### PR DESCRIPTION
## Summary
- simplify auto-tag flow to always dispatch publish workflow explicitly (no polling for implicit tag-trigger)
- dispatch publish workflow on the tag ref, not main
- pass dry_run from release workflow to publish workflow dispatch
- update publish workflow to accept workflow_dispatch dry_run input
- skip upload jobs in publish workflow when dry_run is true
- make cleanup require a discovered run id (fail if publish run cannot be found)

## Why
Tag-push workflow chaining is not reliable in this setup, and polling for implicit trigger adds complexity.
Explicit dispatch is simpler and deterministic.
Also, dispatching on tag ref ensures publish builds the tagged release commit.

## Validation
- shell syntax checks passed for updated scripts
- logic reviewed for dry-run propagation from release -> auto-tag -> publish
