### PR TITLE
Fix release publish run correlation and tag latest main

### DIFF
--- a/.github/actions/dispatch-publish-workflow/action.yml
+++ b/.github/actions/dispatch-publish-workflow/action.yml
@@ -57,6 +57,7 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         REF: ${{ inputs.ref }}
         WORKFLOW_FILE: ${{ inputs.workflow_file }}
+        DISPATCHED_AT: ${{ steps.dispatch.outputs.dispatched_at }}
         DISCOVER_TIMEOUT_SECONDS: ${{ inputs.discover_timeout_seconds }}
         POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
       run: bash ${{ github.action_path }}/discover-run.sh

--- a/.github/actions/dispatch-publish-workflow/discover-run.sh
+++ b/.github/actions/dispatch-publish-workflow/discover-run.sh
@@ -5,11 +5,15 @@ REF="${REF:?REF is required}"
 WORKFLOW_FILE="${WORKFLOW_FILE:-publish.yaml}"
 DISCOVER_TIMEOUT_SECONDS="${DISCOVER_TIMEOUT_SECONDS:-120}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+DISPATCHED_AT="${DISPATCHED_AT:-}"
 
 elapsed=0
 run_id=""
 
 echo "⏳ Waiting for dispatched workflow run to appear for ref ${REF}..."
+if [ -n "${DISPATCHED_AT}" ]; then
+  echo "🔎 Filtering runs created at or after dispatch time: ${DISPATCHED_AT}"
+fi
 
 while [ "$elapsed" -lt "$DISCOVER_TIMEOUT_SECONDS" ]; do
   run_id="$(gh run list \
@@ -17,7 +21,9 @@ while [ "$elapsed" -lt "$DISCOVER_TIMEOUT_SECONDS" ]; do
     --event workflow_dispatch \
     --json databaseId,headBranch,createdAt \
     --limit 50 \
-    --jq ".[] | select(.headBranch==\"${REF}\") | .databaseId" | head -n 1 || true)"
+    | jq -r --arg ref "${REF}" --arg dispatched_at "${DISPATCHED_AT}" \
+      '.[] | select(.headBranch == $ref and ($dispatched_at == "" or .createdAt >= $dispatched_at)) | .databaseId' \
+    | head -n 1 || true)"
 
   if [ -n "${run_id}" ] && [ "${run_id}" != "null" ]; then
     break

--- a/.github/actions/dispatch-publish-workflow/dispatch-workflow.sh
+++ b/.github/actions/dispatch-publish-workflow/dispatch-workflow.sh
@@ -5,8 +5,9 @@ GH_TOKEN="${GH_TOKEN:?GH_TOKEN is required}"
 REF="${REF:?REF is required}"
 WORKFLOW_FILE="${WORKFLOW_FILE:-publish.yaml}"
 DRY_RUN="${DRY_RUN:-false}"
+DISPATCHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-echo "🚀 Dispatching ${WORKFLOW_FILE} on ref ${REF} (dry_run=${DRY_RUN})..."
+echo "🚀 Dispatching ${WORKFLOW_FILE} on ref ${REF} (dry_run=${DRY_RUN}) at ${DISPATCHED_AT}..."
 gh workflow run "${WORKFLOW_FILE}" --ref "${REF}" --field dry_run="${DRY_RUN}"
 echo "✅ Dispatch requested"
 
@@ -15,4 +16,5 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "workflow_file=${WORKFLOW_FILE}" >> "${GITHUB_OUTPUT}"
   echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
   echo "dry_run=${DRY_RUN}" >> "${GITHUB_OUTPUT}"
+  echo "dispatched_at=${DISPATCHED_AT}" >> "${GITHUB_OUTPUT}"
 fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,8 +106,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure latest main
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
 
       - name: Create and tag release
         uses: ./.github/actions/auto-tag-release


### PR DESCRIPTION
## Summary
- make publish run discovery correlate runs by dispatch timestamp as well as ref
- ensure auto-tag job updates to latest origin/main before creating release tag

## Root cause fixed
The release workflow incorrectly picked a previous successful publish run for the same tag ref, causing false success while the newly dispatched publish run later failed in TestPyPI.

## Why this happened
- run discovery looked for the first workflow_dispatch run matching headBranch and tag only
- repeated releases on the same tag can have multiple matching runs

## Changes
- dispatch step now emits dispatched_at
- discover step filters to runs with createdAt greater than or equal to dispatched_at
- auto-tag job now fetches and hard-resets to latest origin/main before tagging

## Validation
- shell syntax checks pass for updated scripts

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--158.org.readthedocs.build/en/158/

<!-- readthedocs-preview mocksafe end -->