### PR TITLE
Revert accidental bump to 0.12.0-beta on main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@
     :target: https://github.com/dmayo3/mocksafe/blob/main/LICENSE
     :alt: MIT License
 
-MockSafe v0.12.0-beta
+MockSafe v0.11.0-beta
 ---------------------
 
 A mocking library developed to enable static and runtime type checking of your mocks to help keep them up-to-date with your production code.
@@ -41,13 +41,13 @@ Install and quickstart
 
     pip install mocksafe
 
-`Library Usage <https://mocksafe.readthedocs.io/en/0.12.0-beta/usage.html>`_
+`Library Usage <https://mocksafe.readthedocs.io/en/0.11.0-beta/usage.html>`_
 
 Links
 ----------------------
 
 :Install: `PyPi <https://pypi.org/project/mocksafe>`_
-:Docs:    `Read The Docs <https://mocksafe.readthedocs.io/en/0.12.0-beta/>`_
+:Docs:    `Read The Docs <https://mocksafe.readthedocs.io/en/0.11.0-beta/>`_
 :License: `MIT <https://github.com/dmayo3/mocksafe/blob/main/LICENSE>`_
 :Source:  `GitHub <https://github.com/dmayo3/mocksafe>`_
 :Issues:  `GitHub Issues <https://github.com/dmayo3/mocksafe/issues>`_

--- a/mocksafe/__init__.py
+++ b/mocksafe/__init__.py
@@ -32,7 +32,7 @@ from mocksafe.apis.bdd import (
     spy,
 )
 
-__version__ = "0.12.0-beta"
+__version__ = "0.11.0-beta"
 
 __all__ = [
     "MockProperty",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mocksafe"
-version = "0.12.0-beta"
+version = "0.11.0-beta"
 
 description = "A mocking library developed to enable static and runtime type checking of your mocks to keep them in sync with production code."
 
@@ -46,7 +46,7 @@ keywords = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://mocksafe.readthedocs.io/en/0.12.0-beta/"
+Documentation = "https://mocksafe.readthedocs.io/en/0.11.0-beta/"
 Source = "https://github.com/dmayo3/mocksafe"
 
 [build-system]
@@ -60,7 +60,7 @@ mocksafe = ["py.typed"]
 mocksafe = "mocksafe.plugin"
 
 [tool.bumpver]
-current_version = "0.12.0-beta"
+current_version = "0.11.0-beta"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
## Summary
- revert versioned files on main from 0.12.0-beta back to 0.11.0-beta
  - pyproject.toml
  - mocksafe/__init__.py
  - README.rst

## Why
An unintended release PR merged and advanced version references to 0.12.0-beta before 0.11.0-beta completion and release notes finalization.

## Validation
- confirmed file versions align at 0.11.0-beta after this change

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--161.org.readthedocs.build/en/161/

<!-- readthedocs-preview mocksafe end -->