### PR TITLE
Add requests compatibility tests under tests/compat/requests (#49)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "pylint >= 3.3.0",
     "pytest >= 8.4.0",
     "pytest-sugar >= 1.0.0",
+    "requests >= 2.32.0",
     "sphinx-rtd-theme >= 1.5.0"
 ]
 

--- a/tests/compat/requests/test_requests_compat.py
+++ b/tests/compat/requests/test_requests_compat.py
@@ -1,0 +1,113 @@
+"""Compatibility tests for mocking popular `requests` workflows with MockSafe.
+
+These tests intentionally avoid real network calls and instead focus on patterns
+developers commonly use in application code:
+- module-level helpers (e.g. ``requests.get``)
+- session-based calls (e.g. ``requests.Session.request``)
+- error paths via ``requests.exceptions``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mocksafe import mock, mock_module, that, when
+
+requests = pytest.importorskip("requests")
+
+
+def test_requests_module_get_with_kwargs_and_json_response() -> None:
+    mock_requests = mock_module(requests)
+    mock_response = mock(requests.Response)
+    payload: dict[str, Any] = {"status": "ok", "count": 2}
+
+    when(mock_response.json).any_call().then_return(payload)
+    when(mock_requests.get).called_with(
+        mock_requests.get(
+            "https://api.example.com/widgets",
+            params={"kind": "popular"},
+            headers={"x-request-id": "abc123"},
+            timeout=1.5,
+        )
+    ).then_return(mock_response)
+
+    response = mock_requests.get(
+        "https://api.example.com/widgets",
+        params={"kind": "popular"},
+        headers={"x-request-id": "abc123"},
+        timeout=1.5,
+    )
+
+    assert response.json() == payload
+    assert that(mock_requests.get).was_called
+    assert that(mock_requests.get).last_call == (
+        ("https://api.example.com/widgets",),
+        {
+            "params": {"kind": "popular"},
+            "headers": {"x-request-id": "abc123"},
+            "timeout": 1.5,
+        },
+    )
+
+
+def test_requests_module_get_timeout_error_path() -> None:
+    mock_requests = mock_module(requests)
+
+    when(mock_requests.get).any_call().then_raise(
+        requests.exceptions.Timeout("request timed out")
+    )
+
+    with pytest.raises(requests.exceptions.Timeout):
+        mock_requests.get("https://api.example.com/slow", timeout=0.1)
+
+    assert that(mock_requests.get).num_calls == 1
+
+
+def test_requests_session_request_happy_path() -> None:
+    mock_session = mock(requests.Session)
+    mock_response = mock(requests.Response)
+
+    when(mock_response.json).any_call().then_return({"id": "w-42"})
+    when(mock_session.request).called_with(
+        mock_session.request("GET", "https://api.example.com/widgets/w-42", timeout=2.0)
+    ).then_return(mock_response)
+
+    response = mock_session.request(
+        "GET", "https://api.example.com/widgets/w-42", timeout=2.0
+    )
+
+    assert response.json()["id"] == "w-42"
+    assert that(mock_session.request).last_call == (
+        ("GET", "https://api.example.com/widgets/w-42"),
+        {"timeout": 2.0},
+    )
+
+
+def test_requests_response_raise_for_status_error_path() -> None:
+    mock_response = mock(requests.Response)
+
+    when(mock_response.raise_for_status).any_call().then_raise(
+        requests.exceptions.HTTPError("500 Server Error")
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        mock_response.raise_for_status()
+
+    assert that(mock_response.raise_for_status).was_called
+
+
+def test_requests_module_get_multiple_calls_and_call_history() -> None:
+    mock_requests = mock_module(requests)
+    mock_response = mock(requests.Response)
+
+    when(mock_requests.get).any_call().then_return(mock_response)
+
+    mock_requests.get("https://api.example.com/one")
+    mock_requests.get("https://api.example.com/two")
+    mock_requests.get("https://api.example.com/three")
+
+    assert that(mock_requests.get).num_calls == 3
+    assert that(mock_requests.get).nth_call(1) == ("https://api.example.com/two",)
+    assert that(mock_requests.get).last_call == ("https://api.example.com/three",)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest~=8.4
     pytest-sugar~=1.0
     coverage~=7.10
+    requests~=2.32
 commands =
     coverage run -m pytest {posargs:tests}
     coverage html
@@ -20,6 +21,7 @@ description = run mypy checks
 deps =
     pytest>=8.4
     mypy>=1.17.0
+    requests~=2.32
 commands =
     mypy --check-untyped-defs {posargs:mocksafe tests}
 
@@ -31,6 +33,7 @@ description = run pyright checks
 deps =
     pytest~=8.4
     pyright
+    requests~=2.32
 commands =
     pyright {posargs:mocksafe tests}
 

--- a/uv.lock
+++ b/uv.lock
@@ -835,6 +835,7 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-sugar" },
+    { name = "requests" },
     { name = "sphinx-rtd-theme" },
 ]
 
@@ -864,6 +865,7 @@ dev = [
     { name = "pylint", specifier = ">=3.3.0" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "sphinx-rtd-theme", specifier = ">=1.5.0" },
 ]
 


### PR DESCRIPTION
## Summary

This PR starts issue #49 by adding a first real-world compatibility slice for the popular requests library.

Scope is intentionally small and non-breaking:
- no runtime API changes in mocksafe
- no new runtime dependencies in the released package
- only test/dev-time dependency and tests

## What changed

- Added segregated compatibility tests in tests/compat/requests/test_requests_compat.py
- Added requests as a dev/test dependency in pyproject.toml and tox.ini test/type-check env deps

## Coverage added

- Module-level requests.get with kwargs and response.json stubbing
- Session-style requests.Session.request flow
- Error paths for Timeout and HTTPError
- Call verification via was_called, num_calls, nth_call, last_call

All tests are network-free and deterministic.

## Validation run

- uv run pytest tests/compat/requests/test_requests_compat.py -> 5 passed
- uv run pytest tests/compat -> 5 passed
- uv run pytest tests -> 189 passed
- uvx tox -e mypy -- tests/compat/requests/test_requests_compat.py -> success
- uvx tox -e pyright -- tests/compat/requests/test_requests_compat.py -> 0 errors (warnings only)
- uvx tox -e lint -- tests/compat/requests/test_requests_compat.py -> success

## Pain points observed

Nothing blocking in this slice.

Mild ergonomics/type-signal pain points:
1. that(...).last_call / nth_call(...) still show partially-unknown typing in pyright warning mode.
2. Real-world requests usage can be somewhat verbose (mock module + mock response object).
3. Sync patterns work well here; async ecosystems like httpx should be validated separately.

## Why this is safe

- Additive tests only + dev/test dependency only
- No public API behavior change
- No packaged/runtime dependency increase
- Easy to revert or iterate

Closes #49

<!-- readthedocs-preview mocksafe start -->
----
📚 Documentation preview 📚: https://mocksafe--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview mocksafe end -->